### PR TITLE
feat: filter by team-repository

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -33,7 +33,20 @@
               </mat-option>
             </mat-select>
           </mat-form-field>
-        </span>
+          </span>
+          <br/>
+          <span>
+          <mat-form-field appearance="outline">
+            <mat-label>repositories</mat-label>
+            <mat-select multiple [formControlName]="teamRepositoriesSelectionControlKey">
+              <mat-optgroup *ngFor="let teamRepository of teamRepositories$ | async" [label]="'Team ' + teamRepository.team.slug">
+              <mat-option *ngFor="let repository of teamRepository.repositories" [value]="{team: teamRepository.team, repository: repository}">
+                {{ repository.name }}
+              </mat-option>
+              </mat-optgroup>
+            </mat-select>
+          </mat-form-field>
+          </span>
           <br/>
           <mat-form-field appearance="outline">
             <mat-label>Status</mat-label>

--- a/src/app/state/configuration/configuration-state.ts
+++ b/src/app/state/configuration/configuration-state.ts
@@ -1,4 +1,4 @@
-import { GitHubTeamModel } from '../../git-hub.service';
+import { GitHubTeamModel, GitHubTeamRepositoryModel } from '../../git-hub.service';
 
 export interface ConfigurationState {
   pollingInterval: number,
@@ -6,6 +6,7 @@ export interface ConfigurationState {
     conclusion: string[],
     status: string[],
     teams: GitHubTeamModel[],
+    teamRepository: GitHubTeamRepositoryModel[],
     workflowNames: string[],
   }
 }

--- a/src/app/state/configuration/configuration.actions.ts
+++ b/src/app/state/configuration/configuration.actions.ts
@@ -11,6 +11,11 @@ export const changeTeamsFilter = createAction(
   props<{ filter: GitHubTeamModel[] }>(),
 );
 
+export const changeTeamRepositoryFilter = createAction(
+    '[Configuration] Change Repos Filter',
+    props<{ filter: any[] }>(),
+);
+
 export const changeStatusFilter = createAction(
   '[Configuration] Change Status Filter',
   props<{ filter: string[] }>(),

--- a/src/app/state/configuration/configuration.reducer.ts
+++ b/src/app/state/configuration/configuration.reducer.ts
@@ -4,7 +4,7 @@ import {
   addWorkflowNameFilter,
   changeConclusionFilter,
   changePollingInterval,
-  changeStatusFilter,
+  changeStatusFilter, changeTeamRepositoryFilter,
   changeTeamsFilter, removeWorkflowNameFilter,
 } from './configuration.actions';
 import { WorkflowRunStatus } from '../../workflow-run/workflow-run-status.enum';
@@ -17,6 +17,7 @@ const initialState: ConfigurationState = {
   pollingInterval: 30,
   filter: {
     teams: [],
+    teamRepository: [],
     status: Object.values(WorkflowRunStatus),
     conclusion: Object.values(WorkflowRunConclusion),
     workflowNames: [],
@@ -30,6 +31,17 @@ export const configurationReducer = createRehydrateReducer(
     ...state,
     filter: {
       teams: filter,
+      teamRepository: state.filter.teamRepository,
+      status: state.filter.status,
+      conclusion: state.filter.conclusion,
+      workflowNames: state.filter.workflowNames,
+    },
+  })),
+  on(changeTeamRepositoryFilter, (state, { filter }): ConfigurationState => ({
+    ...state,
+    filter: {
+      teams: state.filter.teams,
+      teamRepository: filter,
       status: state.filter.status,
       conclusion: state.filter.conclusion,
       workflowNames: state.filter.workflowNames,
@@ -39,6 +51,7 @@ export const configurationReducer = createRehydrateReducer(
     ...state,
     filter: {
       teams: state.filter.teams,
+      teamRepository: state.filter.teamRepository,
       status: filter,
       conclusion: state.filter.conclusion,
       workflowNames: state.filter.workflowNames,
@@ -48,6 +61,7 @@ export const configurationReducer = createRehydrateReducer(
     ...state,
     filter: {
       teams: state.filter.teams,
+      teamRepository: state.filter.teamRepository,
       status: state.filter.status,
       conclusion: filter,
       workflowNames: state.filter.workflowNames,
@@ -61,6 +75,7 @@ export const configurationReducer = createRehydrateReducer(
     ...state,
     filter: {
       teams: state.filter.teams,
+      teamRepository: state.filter.teamRepository,
       status: state.filter.status,
       conclusion: state.filter.conclusion,
       workflowNames: [...new Set([...state.filter.workflowNames, filter])],
@@ -70,6 +85,7 @@ export const configurationReducer = createRehydrateReducer(
     ...state,
     filter: {
       teams: state.filter.teams,
+      teamRepository: state.filter.teamRepository,
       status: state.filter.status,
       conclusion: state.filter.conclusion,
       workflowNames: state.filter.workflowNames.filter(it => it !== filter),

--- a/src/app/state/configuration/configuration.selectors.ts
+++ b/src/app/state/configuration/configuration.selectors.ts
@@ -9,6 +9,11 @@ export const selectTeamsFilter = createSelector(
   (state: ConfigurationState) => state.filter.teams,
 )
 
+export const selectTeamRepositoryFilter = createSelector(
+  selectConfigurationState,
+  (state: ConfigurationState) => state.filter.teamRepository,
+)
+
 export const selectStatusFilter = createSelector(
   selectConfigurationState,
   (state: ConfigurationState) => state.filter.status,

--- a/src/app/state/user/user-state.ts
+++ b/src/app/state/user/user-state.ts
@@ -1,7 +1,8 @@
-import { GitHubRateLimitModel, GitHubTeamModel, GitHubUser } from '../../git-hub.service';
+import { GitHubRateLimitModel, GitHubTeamModel, GitHubTeamRepositoriesModel, GitHubUser } from '../../git-hub.service';
 
 export interface UserState {
   profile: GitHubUser | null,
   rateLimits: GitHubRateLimitModel,
   teams: GitHubTeamModel[],
+  teamRepositories: GitHubTeamRepositoriesModel[],
 }

--- a/src/app/state/user/user.actions.ts
+++ b/src/app/state/user/user.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { GitHubRateLimitModel, GitHubTeamModel, GitHubUser } from '../../git-hub.service';
+import { GitHubRateLimitModel, GitHubTeamModel, GitHubTeamRepositoriesModel, GitHubUser } from '../../git-hub.service';
 
 export const loginSuccess = createAction(
   '[GitHub API] Login Success',
@@ -18,4 +18,9 @@ export const loadRateLimitSuccess = createAction(
 export const loadTeamsSuccess = createAction(
   '[GitHub API] Load Teams Success',
   props<{ teams: GitHubTeamModel[] }>(),
+);
+
+export const loadTeamRepositoriesSuccess = createAction(
+  '[GitHub API] Load Team Repositories Success',
+  props<{ teamRepositories: GitHubTeamRepositoriesModel[] }>(),
 );

--- a/src/app/state/user/user.effects.ts
+++ b/src/app/state/user/user.effects.ts
@@ -1,8 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { changeToken } from '../configuration/configuration.actions';
-import { catchError, map, mergeMap, of } from 'rxjs';
-import { loadRateLimitSuccess, loadTeamsSuccess, loginFailure, loginSuccess } from './user.actions';
+import { catchError, forkJoin, map, mergeMap, of } from 'rxjs';
+import {
+  loadRateLimitSuccess,
+  loadTeamRepositoriesSuccess,
+  loadTeamsSuccess,
+  loginFailure,
+  loginSuccess
+} from './user.actions';
 import { GitHubService } from '../../git-hub.service';
 import { pollWorkflowsRunsSuccess } from '../workflow/workflow.actions';
 
@@ -33,6 +39,15 @@ export class UserEffects {
       ofType(loginSuccess),
       mergeMap(_ => this.gitHubService.loadTeams()),
       map(teams => loadTeamsSuccess({ teams })),
+    )
+  });
+
+  loadTeamRepositories$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(loadTeamsSuccess),
+      map(it => it.teams),
+      mergeMap(teams => forkJoin(teams.map(team => this.gitHubService.loadTeamRepositories(team)))),
+      map(teamRepositories => loadTeamRepositoriesSuccess({ teamRepositories })),
     )
   });
 

--- a/src/app/state/user/user.reducer.ts
+++ b/src/app/state/user/user.reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store';
-import { loadRateLimitSuccess, loadTeamsSuccess, loginFailure, loginSuccess } from './user.actions';
+import { loadRateLimitSuccess, loadTeamRepositoriesSuccess, loadTeamsSuccess, loginFailure, loginSuccess } from './user.actions';
 import { UserState } from './user-state';
 import { GitHubRateLimitModel } from '../../git-hub.service';
 
@@ -7,6 +7,7 @@ const initialState: UserState = {
   profile: null,
   rateLimits: {} as GitHubRateLimitModel,
   teams: [],
+  teamRepositories: []
 }
 
 export const userReducer = createReducer(
@@ -23,5 +24,9 @@ export const userReducer = createReducer(
   on(loadTeamsSuccess, (state, { teams }): UserState => ({
     ...state,
     teams,
+  })),
+  on(loadTeamRepositoriesSuccess, (state, { teamRepositories }): UserState => ({
+    ...state,
+    teamRepositories,
   })),
 );

--- a/src/app/state/user/user.selectors.ts
+++ b/src/app/state/user/user.selectors.ts
@@ -35,3 +35,8 @@ export const selectFilteredUserTeams = createSelector(
       .filter(team => filter.map(it => `${it.organization}-${it.slug}`).includes(`${team.organization}-${team.slug}`))
   },
 )
+
+export const selectTeamRepositories = createSelector(
+  selectUserFeature,
+  (state: UserState) => state.teamRepositories,
+)


### PR DESCRIPTION
Introduce feature filter by team-repository.
When teams laded successfully, the repositories will also load. New filter introduced: filter by repository.
The repositories will now not be reloaded again because the service is using the currently filtered repositories.
The service is not automatically pulling if the repository filter changes unlike if the teams filter changes.
Left some TODOs because of laziness ;)