### PR TITLE
docs: use same port number in docker command and in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docker run --rm -p 8888:80 ghcr.io/fortis-it-services/actio:${MY_DESIRED_VERSION
 ```
 to stick to a specific release.
 
-After that you can access actio via <http://localhost:8080>.
+After that you can access actio via <http://localhost:8888>.
 
 ## GitHub Personal Access Token
 At minimum, the following scopes needs to be [configured](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for your personal access token:


### PR DESCRIPTION
Changed port number to correspond to the one used in the docker cmd